### PR TITLE
Add support for custom Friendly Names for truststores

### DIFF
--- a/pkcs12.go
+++ b/pkcs12.go
@@ -555,7 +555,9 @@ func Encode(rand io.Reader, privateKey interface{}, certificate *x509.Certificat
 // and contains the certificates.
 //
 // The Subject of the certificates are used as the Friendly Names (Aliases)
-// within the resulting pfxData.
+// within the resulting pfxData. If certificates share a Subject, then the
+// resulting Friendly Names (Aliases) will be identical, which Java may treat as
+// the same entry when used as a Java TrustStore, e.g. with `keytool`.
 func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string) (pfxData []byte, err error) {
 	var certsWithFriendlyNames []CertWithFriendlyName
 	for _, cert := range certs {
@@ -581,6 +583,10 @@ type CertWithFriendlyName struct {
 // This is identical to EncodeTruststore, but also allows for setting specific
 // Friendly Names (Aliases) to be used per certificate, by specifying a slice
 // of CertWithFriendlyName.
+//
+// If the same Friendly Name is used for more than one certificate, then the
+// resulting Friendly Names (Aliases) in the pfxData will be identical, which Java
+// may treat as the same entry when used as a Java TrustStore, e.g. with `keytool`.
 //
 // Due to the weak encryption primitives used by PKCS#12, it is RECOMMENDED that
 // you specify a hard-coded password (such as pkcs12.DefaultPassword) and protect

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -553,7 +553,45 @@ func Encode(rand io.Reader, privateKey interface{}, certificate *x509.Certificat
 //
 // EncodeTrustStore creates a single SafeContents that's encrypted with RC2
 // and contains the certificates.
+//
+// The Subject of the certificates are used as the Friendly Names (Aliases)
+// within the resulting pfxData.
 func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string) (pfxData []byte, err error) {
+	var certsWithFriendlyNames []CertWithFriendlyName
+	for _, cert := range certs {
+		certsWithFriendlyNames = append(certsWithFriendlyNames, CertWithFriendlyName{
+			Cert:         cert,
+			FriendlyName: cert.Subject.String(),
+		})
+	}
+	return EncodeTrustStoreWithFriendlyNames(rand, certsWithFriendlyNames, password)
+}
+
+// CertWithFriendlyName contains an X509 Certificate, along with the Friendly Name
+// (Alias) to be used for it when encoded into pfxData.
+type CertWithFriendlyName struct {
+	Cert         *x509.Certificate
+	FriendlyName string
+}
+
+// EncodeTrustStoreWithFriendlyNames produces pfxData containing any number of CA
+// certificates (certs) to be trusted. The certificates will be marked with a
+// special OID that allow it to be used as a Java TrustStore in Java 1.8 and newer.
+//
+// This is identical to EncodeTruststore, but also allows for setting specific
+// Friendly Names (Aliases) to be used per certificate, by specifying a slice
+// of CertWithFriendlyName.
+//
+// Due to the weak encryption primitives used by PKCS#12, it is RECOMMENDED that
+// you specify a hard-coded password (such as pkcs12.DefaultPassword) and protect
+// the resulting pfxData using other means.
+//
+// The rand argument is used to provide entropy for the encryption, and
+// can be set to rand.Reader from the crypto/rand package.
+//
+// EncodeTrustStoreWithFriendlyNames creates a single SafeContents that's encrypted
+// with RC2 and contains the certificates.
+func EncodeTrustStoreWithFriendlyNames(rand io.Reader, certsWithFriendlyNames []CertWithFriendlyName, password string) (pfxData []byte, err error) {
 	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
 		return nil, err
@@ -582,9 +620,9 @@ func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string
 	})
 
 	var certBags []safeBag
-	for _, cert := range certs {
+	for _, certWithFriendlyName := range certsWithFriendlyNames {
 
-		bmpFriendlyName, err := bmpString(cert.Subject.String())
+		bmpFriendlyName, err := bmpString(certWithFriendlyName.FriendlyName)
 		if err != nil {
 			return nil, err
 		}
@@ -609,7 +647,7 @@ func EncodeTrustStore(rand io.Reader, certs []*x509.Certificate, password string
 			},
 		}
 
-		certBag, err := makeCertBag(cert.Raw, append(certAttributes, friendlyName))
+		certBag, err := makeCertBag(certWithFriendlyName.Cert.Raw, append(certAttributes, friendlyName))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Adds support for providing custom Friendly Names for certificates when encoding a truststore.

Partially resolves SSLMate/go-pkcs12#20